### PR TITLE
Allow sniffs to be included via composer by adding a composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "freshconsulting/wcag_linter",
+    "description": "A PHP_CodeSniffer custom rule (sniff) to detect obvious WCAG 2.0 accessibility violations.",
+    "license": "BSD-3-Clause",
+    "require": {}
+}


### PR DESCRIPTION
I am starting to investigate ways to ensure my WordPress plugin complies with WCAG guidelines and I'm hoping to automate it and integrate it into my existing phpcs sniffs and run it on pull requests and such via Travis.

My project is built around composer and I can add this set of sniffs to my project via Composer _if_ there's a composer.json file included.

Add the repo as a repository in my projects (or someone else's projects) composer file:

```json
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/FreshConsulting/FreshConsulting-WCAG-Linter"
    }
  ]
```

Then declare it as a dev requirements:

```json
  "require-dev": {
    "freshconsulting/wcag_linter": "dev-master"
  }
```

It can now be automatically installed via composer which will make using it really easy for me (and I hope others).

Hopefully ya'll can add this for me otherwise I'll just continue working off my fork.

Thanks!